### PR TITLE
增强匹配html标签的兼容性，html属性名可以为汉字或特殊字符

### DIFF
--- a/src/parser/dom.js
+++ b/src/parser/dom.js
@@ -23,7 +23,7 @@ TEXT_NODE = 'text'
 
 //http://haacked.com/archive/2004/10/25/usingregularexpressionstomatchhtml.aspx/
 ATTRIBUTE_REG = /(?:[\w-:]+)(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^'">\s]*))?/g
-HTML_TAG_REG = /<\/?(\w+)((?:\s+(?:[\w-:]+)(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^'">\s]*))?)+\s*|\s*)\/?\>/g
+HTML_TAG_REG = /<\/?(\w+)((?:\s+(?:[^\s=]+)(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^'">\s]*))?)+\s*|\s*)\/?\>/g
 
 HTML_COMMENT_REG = /<!--(.|\s)*?-->/g
 


### PR DESCRIPTION
增强匹配html标签的兼容性，形如 <span style="font-family:" 微软雅黑""=""></span>不是预期的，但是是可能被用户导入的