### PR TITLE
必须从字符串最前面开始匹配，因为有时候html属性值中有字符串</

### DIFF
--- a/src/parser/dom.js
+++ b/src/parser/dom.js
@@ -53,7 +53,7 @@ function collectTags(structure,template) {
     })
     structure.end++
 
-    if (/<\/\w+/.test(match)) {
+    if (/^<\/\w+/.test(match)) {
       structure[structure.end].isEnd = true
     } else if (attrString !== '') {
       structure[structure.end].attrs = analyzeAttributes(attrString)


### PR DESCRIPTION
必须从html标签字符串最前面开始匹配tag，因为有时候html属性中还有html标签，例如
```html
<img alt="a=x<SUB>2</SUB>+y<SUB>2</SUB>">
```
虽然是不符合预期的，但可能被用户使用